### PR TITLE
Convert exampleBatcher.swift to an XCTest

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,8 +2,10 @@
 ;;; For more information see (info "(emacs) Directory Variables")
 
 ((swift-mode
-  (swift-mode:parenthesized-expression-offset . 4)
   (swift-mode:multiline-statement-offset . 4)
+  (swift-mode:parenthesized-expression-offset . 4)
   (swift-mode:basic-offset . 4)))
+
+
 
 

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,9 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((swift-mode
+  (swift-mode:parenthesized-expression-offset . 4)
+  (swift-mode:multiline-statement-offset . 4)
+  (swift-mode:basic-offset . 4)))
+
+

--- a/Package.swift
+++ b/Package.swift
@@ -5,15 +5,15 @@ import PackageDescription
 let package = Package(
     name: "SwiftData",
     products: [
-      .library( name: "Batcher", targets: ["Batcher"]),
-      .library( name: "Batcher1", targets: ["Batcher1"]),
-      .library( name: "Batcher2", targets: ["Batcher2"]),
-      .library( name: "Epochs", targets: ["Epochs"])
+      .library(name: "Batcher", targets: ["Batcher"]),
+      .library(name: "Batcher1", targets: ["Batcher1"]),
+      .library(name: "Batcher2", targets: ["Batcher2"]),
+      .library(name: "Epochs", targets: ["Epochs"])
     ],
     targets: [
-      .target( name: "Batcher", path: "Batcher"),
-      .target( name: "Batcher1", path: "Batcher1"),
-      .target( name: "Batcher2", path: "Batcher2"),
-      .target( name: "Epochs", path: "Epochs")
+      .target(name: "Batcher", path: "Batcher"),
+      .target(name: "Batcher1", path: "Batcher1"),
+      .target(name: "Batcher2", path: "Batcher2"),
+      .target(name: "Epochs", path: "Epochs")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,19 +1,23 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 
 import PackageDescription
 
 let package = Package(
     name: "SwiftData",
+    platforms: [ .macOS(.v10_13) ],
     products: [
-      .library(name: "Batcher", targets: ["Batcher"]),
-      .library(name: "Batcher1", targets: ["Batcher1"]),
-      .library(name: "Batcher2", targets: ["Batcher2"]),
-      .library(name: "Epochs", targets: ["Epochs"])
+        .library(name: "Batcher", targets: ["Batcher"]),
+        .library(name: "Batcher1", targets: ["Batcher1"]),
+        .library(name: "Batcher2", targets: ["Batcher2"]),
+        .library(name: "Epochs", targets: ["Epochs"])
     ],
     targets: [
-      .target(name: "Batcher", path: "Batcher"),
-      .target(name: "Batcher1", path: "Batcher1"),
-      .target(name: "Batcher2", path: "Batcher2"),
-      .target(name: "Epochs", path: "Epochs")
-    ]
-)
+        .target(name: "Batcher", path: "Batcher"),
+        .testTarget(
+            name: "exampleBatcher",
+            dependencies: ["Batcher"],
+            path: "examples", sources: ["exampleBatcher.swift"]),
+        .target(name: "Batcher1", path: "Batcher1"),
+        .target(name: "Batcher2", path: "Batcher2"),
+        .target(name: "Epochs", path: "Epochs")
+    ])

--- a/examples/exampleBatcher.swift
+++ b/examples/exampleBatcher.swift
@@ -1,20 +1,26 @@
 import TensorFlow
 import Batcher
+import XCTest
 
+class BatcherTests : XCTestCase {
 // Base use
+    func test0() {
 // Some raw items (for instance filenames)
 let rawItems = 0..<512
 // A heavy-compute function lazily mapped on it (for instance, opening the images)
 let dataSet = rawItems.lazy.map { _ in Tensor<Float>(randomNormal: [224, 224, 3]) }
+
 // A `Batcher` defined on this:
 let batcher = Batcher(on: dataSet, batchSize: 64)
 // Iteration over it (for instance, on epoch of the training loop) 
 for batch in batcher.sequenced() {
     print(batch.shape)
 }
+}
 
 // Use with padding
 // Let's create an array of things of various lengths (for instance texts)
+let dataSet: [Tensor<Int32>] = { 
 var dataSet: [Tensor<Int32>] = []
 for _ in 0..<512 {
     dataSet.append(Tensor<Int32>(
@@ -23,7 +29,9 @@ for _ in 0..<512 {
         upperBound: Tensor<Int32>(100)
     ))
 }
-
+return dataSet
+}()
+    
 // We need to pad those tensors to make them all the same length.
 // We could do this in one lazy transform applied beforehand and pad everything
 // to the same length, but it's not memory-efficient: some batches might need less
@@ -37,10 +45,12 @@ func padTensors(tensors: [Tensor<Int32>]) -> [Tensor<Int32>] {
     }
 } 
 
+    func test1() {
 let batcher = Batcher(on: dataSet, batchSize: 64, padSamples: padTensors)
 for b in batcher.sequenced() {
     print(b.shape)
 }
+    }
 
 // Use with a sampler
 // In our previous example, another way to be memory efficient is to batch
@@ -51,10 +61,16 @@ func sortSamples(on dataset: inout [Tensor<Int32>], shuffled: Bool) -> [Int] {
     return Array(0..<dataset.count).sorted { dataset[$0].shape[0] > dataset[$1].shape[0] }
 }
 
+    func test2() {
+
+// Use with a sampler
+// In our previous example, another way to be memory efficient is to batch
+// samples of roughly the same lengths.
 let batches = Batcher(on: dataSet, batchSize: 64, sampleIndices: sortSamples, padSamples: padTensors)
 for b in batches.sequenced() {
     print(b.shape)
 }
+    }
 
 // Sometimes the shuffle method needs to be applied on the dataset itself, 
 // like for language modeling. Here is a base version of that to test
@@ -91,8 +107,10 @@ struct DataSet: RandomAccessCollection {
 }
 
 //Let's create such a DataSet
-let numbers: [[Int]] = [[1,2,3,4,5], [6,7,8], [9,10,11,12,13,14,15], [16,17,18]]
-let dataset = DataSet(numbers: numbers, sequenceLength: 3)
+let dataset: DataSet = {
+    let numbers: [[Int]] = [[1,2,3,4,5], [6,7,8], [9,10,11,12,13,14,15], [16,17,18]]
+    return DataSet(numbers: numbers, sequenceLength: 3)
+}()
 
 // This is the sampler we will use: it always returns the default indices
 // and shuffles the dataset if needed
@@ -102,12 +120,18 @@ func internalShuffle(on dataset: inout DataSet, shuffled: Bool) -> [Int] {
 }
 
 //Now let's look at what it gives us:
+func test3() {
 let batcher = Batcher(on: dataset, batchSize: 3, sampleIndices: internalShuffle)
 for b in batcher.sequenced() {
     print(b)
 }
+    }
+
+    func test4() {
 
 let batcher = Batcher(on: dataset, batchSize: 3, shuffle: true, sampleIndices: internalShuffle)
 for b in batcher.sequenced() {
     print(b)
 }
+
+    }}

--- a/examples/exampleBatcher.swift
+++ b/examples/exampleBatcher.swift
@@ -3,135 +3,133 @@ import Batcher
 import XCTest
 
 class BatcherTests : XCTestCase {
-// Base use
+    // Base use
     func test0() {
-// Some raw items (for instance filenames)
-let rawItems = 0..<512
-// A heavy-compute function lazily mapped on it (for instance, opening the images)
-let dataSet = rawItems.lazy.map { _ in Tensor<Float>(randomNormal: [224, 224, 3]) }
+        // Some raw items (for instance filenames)
+        let rawItems = 0..<512
+        // A heavy-compute function lazily mapped on it (for instance, opening the images)
+        let dataSet = rawItems.lazy.map { _ in Tensor<Float>(randomNormal: [224, 224, 3]) }
 
-// A `Batcher` defined on this:
-let batcher = Batcher(on: dataSet, batchSize: 64)
-// Iteration over it (for instance, on epoch of the training loop) 
-for batch in batcher.sequenced() {
-    print(batch.shape)
-}
-}
-
-// Use with padding
-// Let's create an array of things of various lengths (for instance texts)
-let dataSet: [Tensor<Int32>] = { 
-var dataSet: [Tensor<Int32>] = []
-for _ in 0..<512 {
-    dataSet.append(Tensor<Int32>(
-        randomUniform: [Int.random(in: 1...200)], 
-        lowerBound: Tensor<Int32>(0), 
-        upperBound: Tensor<Int32>(100)
-    ))
-}
-return dataSet
-}()
-    
-// We need to pad those tensors to make them all the same length.
-// We could do this in one lazy transform applied beforehand and pad everything
-// to the same length, but it's not memory-efficient: some batches might need less
-// padding. So we need to add the padding after having selected the samples we
-// are trying to batch.
-func padTensors(tensors: [Tensor<Int32>]) -> [Tensor<Int32>] {
-    let maxLength = tensors.map{ $0.shape[0] }.max()!
-    return tensors.map { (t: Tensor<Int32>) -> Tensor<Int32> in 
-        let remaining = Tensor<Int32>(zeros: [maxLength - t.shape[0]])
-        return Tensor<Int32>(concatenating: [t, remaining])
-    }
-} 
-
-    func test1() {
-let batcher = Batcher(on: dataSet, batchSize: 64, padSamples: padTensors)
-for b in batcher.sequenced() {
-    print(b.shape)
-}
-    }
-
-// Use with a sampler
-// In our previous example, another way to be memory efficient is to batch
-// samples of roughly the same lengths.
-func sortSamples(on dataset: inout [Tensor<Int32>], shuffled: Bool) -> [Int] {
-    // Just giving a quick example, but the function should shuffle a bit the sorted thing
-    // if shuffle=true
-    return Array(0..<dataset.count).sorted { dataset[$0].shape[0] > dataset[$1].shape[0] }
-}
-
-    func test2() {
-
-// Use with a sampler
-// In our previous example, another way to be memory efficient is to batch
-// samples of roughly the same lengths.
-let batches = Batcher(on: dataSet, batchSize: 64, sampleIndices: sortSamples, padSamples: padTensors)
-for b in batches.sequenced() {
-    print(b.shape)
-}
-    }
-
-// Sometimes the shuffle method needs to be applied on the dataset itself, 
-// like for language modeling. Here is a base version of that to test
-// the API allows it.
-struct DataSet: RandomAccessCollection {
-    typealias Index = Int
-    typealias Element = Tensor<Int32>
-    
-    let numbers: [[Int]]
-    let sequenceLength: Int
-    // The texts all concatenated together
-    private var stream: [Int]
-    
-    var startIndex: Int { return 0 }
-    var endIndex: Int { return stream.count / sequenceLength }
-    func index(after i: Int) -> Int { i+1 }
-    
-    init(numbers: [[Int]], sequenceLength: Int) {
-        self.numbers = numbers
-        self.sequenceLength = sequenceLength
-        stream = numbers.reduce([], +)
-    }
-    
-    subscript(index: Int) -> Tensor<Int32> {
-        get { 
-            let i = index * sequenceLength
-            return Tensor<Int32>(stream[i..<i+sequenceLength].map { Int32($0)} )
+        // A `Batcher` defined on this:
+        let batcher = Batcher(on: dataSet, batchSize: 64)
+        // Iteration over it (for instance, on epoch of the training loop) 
+        for batch in batcher.sequenced() {
+            print(batch.shape)
         }
     }
+
+    // Use with padding
+    // Let's create an array of things of various lengths (for instance texts)
+    let dataSet: [Tensor<Int32>] = { 
+        var dataSet: [Tensor<Int32>] = []
+        for _ in 0..<512 {
+            dataSet.append(Tensor<Int32>(
+                               randomUniform: [Int.random(in: 1...200)], 
+                               lowerBound: Tensor<Int32>(0), 
+                               upperBound: Tensor<Int32>(100)
+                           ))
+        }
+        return dataSet
+    }()
     
-    mutating func shuffle() {
-        stream = numbers.shuffled().reduce([], +)
+    // We need to pad those tensors to make them all the same length.
+    // We could do this in one lazy transform applied beforehand and pad everything
+    // to the same length, but it's not memory-efficient: some batches might need less
+    // padding. So we need to add the padding after having selected the samples we
+    // are trying to batch.
+    func padTensors(tensors: [Tensor<Int32>]) -> [Tensor<Int32>] {
+        let maxLength = tensors.map{ $0.shape[0] }.max()!
+        return tensors.map { (t: Tensor<Int32>) -> Tensor<Int32> in 
+            let remaining = Tensor<Int32>(zeros: [maxLength - t.shape[0]])
+            return Tensor<Int32>(concatenating: [t, remaining])
+        }
+    } 
+
+    func test1() {
+        let batcher = Batcher(on: dataSet, batchSize: 64, padSamples: padTensors)
+        for b in batcher.sequenced() {
+            print(b.shape)
+        }
     }
-}
 
-//Let's create such a DataSet
-let dataset: DataSet = {
-    let numbers: [[Int]] = [[1,2,3,4,5], [6,7,8], [9,10,11,12,13,14,15], [16,17,18]]
-    return DataSet(numbers: numbers, sequenceLength: 3)
-}()
+    // Use with a sampler
+    // In our previous example, another way to be memory efficient is to batch
+    // samples of roughly the same lengths.
+    func sortSamples(on dataset: inout [Tensor<Int32>], shuffled: Bool) -> [Int] {
+        // Just giving a quick example, but the function should shuffle a bit the sorted thing
+        // if shuffle=true
+        return Array(0..<dataset.count).sorted { dataset[$0].shape[0] > dataset[$1].shape[0] }
+    }
 
-// This is the sampler we will use: it always returns the default indices
-// and shuffles the dataset if needed
-func internalShuffle(on dataset: inout DataSet, shuffled: Bool) -> [Int] {
-    if shuffled { dataset.shuffle() }
-    return Array(0..<dataset.count)
-}
+    func test2() {
+        // Use with a sampler
+        // In our previous example, another way to be memory efficient is to batch
+        // samples of roughly the same lengths.
+        let batches = Batcher(on: dataSet, batchSize: 64, sampleIndices: sortSamples, padSamples: padTensors)
+        for b in batches.sequenced() {
+            print(b.shape)
+        }
+    }
 
-//Now let's look at what it gives us:
-func test3() {
-let batcher = Batcher(on: dataset, batchSize: 3, sampleIndices: internalShuffle)
-for b in batcher.sequenced() {
-    print(b)
-}
+    // Sometimes the shuffle method needs to be applied on the dataset itself, 
+    // like for language modeling. Here is a base version of that to test
+    // the API allows it.
+    struct DataSet: RandomAccessCollection {
+        typealias Index = Int
+        typealias Element = Tensor<Int32>
+        
+        let numbers: [[Int]]
+        let sequenceLength: Int
+        // The texts all concatenated together
+        private var stream: [Int]
+        
+        var startIndex: Int { return 0 }
+        var endIndex: Int { return stream.count / sequenceLength }
+        func index(after i: Int) -> Int { i+1 }
+        
+        init(numbers: [[Int]], sequenceLength: Int) {
+            self.numbers = numbers
+            self.sequenceLength = sequenceLength
+            stream = numbers.reduce([], +)
+        }
+        
+        subscript(index: Int) -> Tensor<Int32> {
+            get { 
+                let i = index * sequenceLength
+                return Tensor<Int32>(stream[i..<i+sequenceLength].map { Int32($0)} )
+            }
+        }
+        
+        mutating func shuffle() {
+            stream = numbers.shuffled().reduce([], +)
+        }
+    }
+
+    //Let's create such a DataSet
+    let dataset: DataSet = {
+        let numbers: [[Int]] = [[1,2,3,4,5], [6,7,8], [9,10,11,12,13,14,15], [16,17,18]]
+        return DataSet(numbers: numbers, sequenceLength: 3)
+    }()
+
+    // This is the sampler we will use: it always returns the default indices
+    // and shuffles the dataset if needed
+    func internalShuffle(on dataset: inout DataSet, shuffled: Bool) -> [Int] {
+        if shuffled { dataset.shuffle() }
+        return Array(0..<dataset.count)
+    }
+
+    //Now let's look at what it gives us:
+    func test3() {
+        let batcher = Batcher(on: dataset, batchSize: 3, sampleIndices: internalShuffle)
+        for b in batcher.sequenced() {
+            print(b)
+        }
     }
 
     func test4() {
-
-let batcher = Batcher(on: dataset, batchSize: 3, shuffle: true, sampleIndices: internalShuffle)
-for b in batcher.sequenced() {
-    print(b)
+        let batcher = Batcher(on: dataset, batchSize: 3, shuffle: true, sampleIndices: internalShuffle)
+        for b in batcher.sequenced() {
+            print(b)
+        }
+    }
 }
-
-    }}


### PR DESCRIPTION
A really good conversion would use `XCTAssert*` calls to validate results, but this at least proves things compile and demonstrates the usage patterns.